### PR TITLE
Update README license to refer to LICENSE.md (GPL -> zlib)

### DIFF
--- a/README.md
+++ b/README.md
@@ -874,17 +874,5 @@ print( a, b ) --> 2, 3
 | mlib.polygon.isCircleCompletelyOver           | [mlib.circleisPolygonCompletelyInside](#mlibcircleispolygoncompletelyinside)      |
 
 ## License
-A math library made in Lua
-copyright (C) 2014 Davis Claiborne
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-You should have received a copy of the GNU General Public License along
-with this program; if not, write to the Free Software Foundation, Inc.,
-51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
-Contact me at davisclaib at gmail.com
+
+zlib license. See LICENSE.md


### PR DESCRIPTION
986d5f9 changed the license to zlib, but missed the readme.

Instead of replicating the license a third time, reference LICENSE.md.