### PR TITLE
Fix typos and globals found by luacheck

### DIFF
--- a/mlib.lua
+++ b/mlib.lua
@@ -553,8 +553,8 @@ end
 
 -- Gives the intersection of a line and a circle.
 local function getCircleLineIntersection( circleX, circleY, radius, x1, y1, x2, y2 )
-	slope = getSlope( x1, y1, x2, y2 )
-	intercept = getYIntercept( x1, y1, slope )
+	local slope = getSlope( x1, y1, x2, y2 )
+	local intercept = getYIntercept( x1, y1, slope )
 
 	if slope then
 		local a = ( 1 + slope ^ 2 )
@@ -986,7 +986,7 @@ end -- }}}
 local function getMean( ... )
 	local input = checkInput( ... )
 
-	mean = getSummation( 1, #input,
+	local mean = getSummation( 1, #input,
 		function( i, t )
 			return input[i]
 		end
@@ -1209,7 +1209,7 @@ local function dist2Vector(a, b)
 end
 
 local function distVector(a, b)
-	return sqrt(dis2Vector(a, b))
+	return sqrt(dist2Vector(a, b))
 end
 
 local function normalizeVector(a)
@@ -1242,7 +1242,7 @@ local function mirrorOnVector(a, b)
 end
 
 local function crossVector(a, b)
-	return a.x * v.y - a.y * v.x
+	return a.x * b.y - a.y * b.x
 end
 
 -- ref.: http://blog.signalsondisplay.com/?p=336


### PR DESCRIPTION
I ran luacheck and while it found lots of frivolous errors, it also
found some significant ones.

Referencing wrong function/var: dis2Vector -> dist2Vector and v -> b. Would cause nil errors.

    mlib.lua:1212 accessing undefined variable 'dis2Vector'
    mlib.lua:1245 accessing undefined variable 'v'

We were accidentally writing slope and intercept as global variables. If
someone's project used these variables, we'd stomp them:

    mlib.lua:556 setting non-standard global variable 'slope'
    mlib.lua:557 setting non-standard global variable 'intercept'
    mlib.lua:989 setting non-standard global variable 'mean'

Luacheck now runs clean on mlib with this .luacheckrc:

```lua
  std = "luajit+lua52"

  max_line_length    = false -- Do not limit line length.

  ignore = {
      '2..', -- Unused variables
      '311', -- Value assigned to a local variable is unused.
      '421', -- Shadowing a local variable.
      '422', -- Shadowing an argument.
      '43.', -- Shadowing upvalues
  }

  include_files = {
      "mlib.lua"
  }
```

Not sure if you wanted that luacheckrc added to the project, so I've just left it here.

Most of those ignored errors seem benign, but there are some cases that might be
bugs:
* isDistanceLess: we define a function (possibly to use as an
  optimization), but never use it.
* y4,x2,...: lots of unused variables that might be typos where we used
  the wrong variable.